### PR TITLE
set repo flags back to true

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -236,8 +236,8 @@ jreleaser {
                 'maven-central' {
                     active = 'ALWAYS'
                     url = 'https://oss.sonatype.org/service/local'
-                    closeRepository = false
-                    releaseRepository = false
+                    closeRepository = true
+                    releaseRepository = true
                     applyMavenCentralRules = true
                     stagingRepository('../build/staging-deploy')
                 }


### PR DESCRIPTION
Set flags back to true so the artifacts dont need to manually be promoted

I was going to up the version to `1.5.3`, but see its already that version, but the last version we released was `1.5.2`.