### PR TITLE
use java 11 everywhere

### DIFF
--- a/azurefunctions/build.gradle
+++ b/azurefunctions/build.gradle
@@ -24,8 +24,8 @@ dependencies {
     compileOnly "com.microsoft.azure.functions:azure-functions-java-spi:1.0.0"
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
 
 publishing {
     repositories {

--- a/azuremanaged/build.gradle
+++ b/azuremanaged/build.gradle
@@ -49,15 +49,13 @@ dependencies {
 }
 
 compileJava {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 compileTestJava {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
-    options.fork = true
-    options.forkOptions.executable = "${PATH_TO_TEST_JAVA_RUNTIME}/bin/javac"
 }
 
 test {

--- a/endtoendtests/build.gradle
+++ b/endtoendtests/build.gradle
@@ -26,8 +26,8 @@ dependencies {
 
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+sourceCompatibility = '11'
+targetCompatibility = '11'
 
 compileJava.options.encoding = 'UTF-8'
 

--- a/samples-azure-functions/build.gradle
+++ b/samples-azure-functions/build.gradle
@@ -26,8 +26,8 @@ dependencies {
 
 }
 
-sourceCompatibility = '1.8'
-targetCompatibility = '1.8'
+sourceCompatibility = '11'
+targetCompatibility = '11'
 
 compileJava.options.encoding = 'UTF-8'
 


### PR DESCRIPTION
use java 11 everywhere && [fix release pipeline failure](https://github.com/dapr/durabletask-java/actions/runs/16659154602/job/47151771131)